### PR TITLE
Replace `i=1` with `i-1` in the term of B in Sec. 3.5

### DIFF
--- a/tex/collection/03concentration.tex
+++ b/tex/collection/03concentration.tex
@@ -255,7 +255,7 @@ We now introduce some important inequalities related to the second of our two go
     Next, we show that conditional on $X_1,\dots,X_{i - 1}$, $D_i$ is a bounded random variable. First, observe that:
     \begin{align*}
         A_i = \inf_x \Exp \left[ f(X_1,\dots,X_n) | X_1,\dots,X_{i - 1}, X_i = x \right] - \Exp \left[ f(X_1,\dots,X_n) | X_1,\dots,X_{i - 1} \right] \\
-        B_i = \sup_x \Exp \left [ f(X_1,\dots,X_n) | X_1,\dots,X_{i = 1}, X_i = x \right] - \Exp \left[ f(X_1,\dots,X_n) | X_1,\dots,X_{i - 1} \right]
+        B_i = \sup_x \Exp \left [ f(X_1,\dots,X_n) | X_1,\dots,X_{i - 1}, X_i = x \right] - \Exp \left[ f(X_1,\dots,X_n) | X_1,\dots,X_{i - 1} \right]
     \end{align*}
     It is clear from their definition that $A_i \leq D_i \leq B_i$. Furthermore, by independence of the $X_i$'s, we have that:
     \begin{align*}


### PR DESCRIPTION
By chance, I found a minor typo as described in the pull request title (specifically, the selected area in the following screenshot)

<img width="877" alt="Screenshot 2022-07-23 at 15 02 57" src="https://user-images.githubusercontent.com/7121753/180606257-652b63f8-d77c-4f63-8d63-4598b6b281e4.png">
